### PR TITLE
Rename ILink.Invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Used to represent a message without any data flowing through a chain.
 
 ### Link
 
-A link is re-usable asynchronous step, its `Invoke` method is called with the input from the previous step. The link then returns the value that should be passed to the next step in the chain.
+A link is re-usable asynchronous step, its `ExecuteAsync` method is called with the input from the previous step. The link then returns the value that should be passed to the next step in the chain.
 
 Links can be either stateful or stateless:
 - `StatefulLink` is instantiated once and the same instance is used for each execution, therefore they can hold state between executions but has to be thread-safe
@@ -207,7 +207,7 @@ public class IntToString : StatefulLink<int, string>
 {
     private long _totalValueSeen = 0;
     
-    protected override ValueTask Invoke(int input, ChainContext context)
+    protected override ValueTask ExecuteAsync(int input, ChainContext context)
     {
         var newTotal = Interlocked.Add(ref _totalValueSeen, input);
         context.Logger.LogInformation($"I've seen a total value of {newTotal}");

--- a/samples/DaisyFx.Samples.KitchenSink/Links/GenerateArray.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/Links/GenerateArray.cs
@@ -12,7 +12,7 @@ namespace DaisyFx.Samples.KitchenSink.Links
             _config = ReadConfiguration<GenerateArrayOptions>();
         }
 
-        protected override ValueTask<int[]> Invoke(string input, ChainContext context)
+        protected override ValueTask<int[]> ExecuteAsync(string input, ChainContext context)
         {
             return new(Enumerable.Range(_config.Start, _config.Count).ToArray());
         }

--- a/samples/DaisyFx.Samples.KitchenSink/Links/LogDateTime.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/Links/LogDateTime.cs
@@ -13,7 +13,7 @@ namespace DaisyFx.Samples.KitchenSink.Links
             _configuration = ReadConfiguration<LogDateTimeConfiguration>();
         }
 
-        protected override ValueTask<DateTime> Invoke(DateTime input, ChainContext context)
+        protected override ValueTask<DateTime> ExecuteAsync(DateTime input, ChainContext context)
         {
             context.Logger.LogInformation(input.ToString(_configuration.DateFormat));
             return new ValueTask<DateTime>();

--- a/samples/DaisyFx.Samples.KitchenSink/Links/LogInformation.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/Links/LogInformation.cs
@@ -5,7 +5,7 @@ namespace DaisyFx.Samples.KitchenSink.Links
 {
     public class LogInformation<T> : StatefulLink<T, T> where T : notnull
     {
-        protected override ValueTask<T> Invoke(T input, ChainContext context)
+        protected override ValueTask<T> ExecuteAsync(T input, ChainContext context)
         {
             context.Logger.LogInformation(input.ToString());
             return new ValueTask<T>(input);

--- a/samples/DaisyFx.Samples.KitchenSink/Links/StringToDateTime.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/Links/StringToDateTime.cs
@@ -6,7 +6,7 @@ namespace DaisyFx.Samples.KitchenSink.Links
 {
     public class StringToDateTime : StatefulLink<string, DateTime>
     {
-        protected override ValueTask<DateTime> Invoke(string input, ChainContext context)
+        protected override ValueTask<DateTime> ExecuteAsync(string input, ChainContext context)
         {
             return new(DateTime.Parse(input, CultureInfo.InvariantCulture));
         }

--- a/samples/DaisyFx.Samples.LoanBroker/Links/ApproveLoan.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Links/ApproveLoan.cs
@@ -13,7 +13,7 @@ namespace DaisyFx.Samples.LoanBroker.Links
             _loanService = loanService;
         }
 
-        protected override async ValueTask<Signal> Invoke(LoanContract loanContract, ChainContext context)
+        protected override async ValueTask<Signal> ExecuteAsync(LoanContract loanContract, ChainContext context)
         {
             await _loanService.ApproveLoanAsync(loanContract, context.CancellationToken);
             return Signal.Static;

--- a/samples/DaisyFx.Samples.LoanBroker/Links/CreateLoanApplication.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Links/CreateLoanApplication.cs
@@ -13,7 +13,7 @@ namespace DaisyFx.Samples.LoanBroker.Links
             _creditService = creditService;
         }
 
-        protected override async ValueTask<LoanApplication> Invoke(LoanInquiry input, ChainContext context)
+        protected override async ValueTask<LoanApplication> ExecuteAsync(LoanInquiry input, ChainContext context)
         {
             var creditReport = await _creditService.GetCreditReportAsync(input.Ssn, context.CancellationToken);
 

--- a/samples/DaisyFx.Samples.LoanBroker/Links/CreateLoanContract.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Links/CreateLoanContract.cs
@@ -15,7 +15,7 @@ namespace DaisyFx.Samples.LoanBroker.Links
             _bankService = bankService;
         }
 
-        protected override async ValueTask<LoanContract> Invoke(LoanApplication input, ChainContext context)
+        protected override async ValueTask<LoanContract> ExecuteAsync(LoanApplication input, ChainContext context)
         {
             var quotes = await _bankService.GetLoanQuotesAsync(input.Amount, input.LoanDuration, input.CreditScore,
                 context.CancellationToken);

--- a/samples/DaisyFx.Samples.LoanBroker/Links/DenyLoan.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Links/DenyLoan.cs
@@ -13,7 +13,7 @@ namespace DaisyFx.Samples.LoanBroker.Links
             _loanService = loanService;
         }
 
-        protected override async ValueTask<Signal> Invoke(LoanApplication loan, ChainContext context)
+        protected override async ValueTask<Signal> ExecuteAsync(LoanApplication loan, ChainContext context)
         {
             await _loanService.DenyLoanAsync(loan, context.CancellationToken);
             return Signal.Static;

--- a/samples/DaisyFx.Samples.LoanBroker/Links/GetLoanInquiry.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Links/GetLoanInquiry.cs
@@ -15,7 +15,7 @@ namespace DaisyFx.Samples.LoanBroker.Links
             _configuration = ReadConfiguration<GetLoanInquiryConfiguration>();
         }
 
-        protected override async ValueTask<LoanInquiry> Invoke(Signal input, ChainContext context)
+        protected override async ValueTask<LoanInquiry> ExecuteAsync(Signal input, ChainContext context)
         {
             return await _loanService.GetLoanInquiryAsync(_configuration.MaxAgeDays, context.CancellationToken);
         }

--- a/samples/DaisyFx.Samples.Webhook/Links/PrintOrderToConsole.cs
+++ b/samples/DaisyFx.Samples.Webhook/Links/PrintOrderToConsole.cs
@@ -8,7 +8,7 @@ namespace DaisyFx.Samples.Webhook.Links
 {
     public class PrintOrderToConsole : StatefulLink<Order, Order>
     {
-        protected override ValueTask<Order> Invoke(Order input, ChainContext context)
+        protected override ValueTask<Order> ExecuteAsync(Order input, ChainContext context)
         {
             var builder = new StringBuilder();
             builder.AppendLine($"OrderDate: {input.OrderDate.ToString(CultureInfo.InvariantCulture)}");

--- a/src/DaisyFx/Connectors/StatefulLinkConnector.cs
+++ b/src/DaisyFx/Connectors/StatefulLinkConnector.cs
@@ -17,7 +17,7 @@ namespace DaisyFx.Connectors
 
         protected override ValueTask<TOutput> ProcessAsync(TInput input, ChainContext context)
         {
-            return _link.Invoke(input, context);
+            return _link.ExecuteAsync(input, context);
         }
 
         protected override void Dispose()

--- a/src/DaisyFx/Connectors/StatelessLinkConnector.cs
+++ b/src/DaisyFx/Connectors/StatelessLinkConnector.cs
@@ -19,7 +19,7 @@ namespace DaisyFx.Connectors
         protected override async ValueTask<TOutput> ProcessAsync(TInput input, ChainContext context)
         {
             using var link = InstanceFactory.Create<TLink>(context.ScopeServices, _context);
-            return await link.Invoke(input, context);
+            return await link.ExecuteAsync(input, context);
         }
     }
 

--- a/src/DaisyFx/ILink.cs
+++ b/src/DaisyFx/ILink.cs
@@ -5,6 +5,6 @@ namespace DaisyFx
 {
     public interface ILink<in TInput, TOutput> : IDisposable
     {
-        ValueTask<TOutput> Invoke(TInput input, ChainContext context);
+        ValueTask<TOutput> ExecuteAsync(TInput input, ChainContext context);
     }
 }

--- a/src/DaisyFx/StatefulLink.cs
+++ b/src/DaisyFx/StatefulLink.cs
@@ -15,9 +15,9 @@ namespace DaisyFx
 
         protected T ReadConfiguration<T>() where T : new() => _context.ReadConfiguration<T>();
 
-        ValueTask<TOutput> ILink<TInput, TOutput>.Invoke(TInput input, ChainContext context) => Invoke(input, context);
+        ValueTask<TOutput> ILink<TInput, TOutput>.ExecuteAsync(TInput input, ChainContext context) => ExecuteAsync(input, context);
 
-        protected abstract ValueTask<TOutput> Invoke(TInput input, ChainContext context);
+        protected abstract ValueTask<TOutput> ExecuteAsync(TInput input, ChainContext context);
 
         void IDisposable.Dispose()
         {

--- a/src/DaisyFx/StatelessLink.cs
+++ b/src/DaisyFx/StatelessLink.cs
@@ -14,9 +14,9 @@ namespace DaisyFx
 
         protected T ReadConfiguration<T>() where T : new() => _context.ReadConfiguration<T>();
 
-        ValueTask<TOutput> ILink<TInput, TOutput>.Invoke(TInput input, ChainContext context) => Invoke(input, context);
+        ValueTask<TOutput> ILink<TInput, TOutput>.ExecuteAsync(TInput input, ChainContext context) => ExecuteAsync(input, context);
 
-        protected abstract ValueTask<TOutput> Invoke(TInput input, ChainContext context);
+        protected abstract ValueTask<TOutput> ExecuteAsync(TInput input, ChainContext context);
 
         void IDisposable.Dispose()
         {

--- a/tests/DaisyFx.TestHelpers/StatefulLinkTestRunner.cs
+++ b/tests/DaisyFx.TestHelpers/StatefulLinkTestRunner.cs
@@ -21,7 +21,7 @@ namespace DaisyFx.TestHelpers
         public async ValueTask<TOutput> ExecuteAsync(TInput input, CancellationToken ct = default)
         {
             using var context = CreateContext(Services, ct);
-            return await _link.Invoke(input, context);
+            return await _link.ExecuteAsync(input, context);
         }
 
         void IDisposable.Dispose()

--- a/tests/DaisyFx.TestHelpers/StatelessLinkTestRunner.cs
+++ b/tests/DaisyFx.TestHelpers/StatelessLinkTestRunner.cs
@@ -11,7 +11,7 @@ namespace DaisyFx.TestHelpers
             using var context = CreateContext(Services, ct);
             using ILink<TInput, TOutput> link = CreateLink(context.ScopeServices);
 
-            return await link.Invoke(input, context);
+            return await link.ExecuteAsync(input, context);
         }
     }
 }

--- a/tests/DaisyFx.Tests/Utils/Links/NoopLink.cs
+++ b/tests/DaisyFx.Tests/Utils/Links/NoopLink.cs
@@ -4,7 +4,7 @@ namespace DaisyFx.Tests.Utils.Links
 {
     public class NoopLink<T> : StatelessLink<T, T>
     {
-        protected override ValueTask<T> Invoke(T input, ChainContext context)
+        protected override ValueTask<T> ExecuteAsync(T input, ChainContext context)
         {
             return new(input);
         }

--- a/tests/DaisyFx.Tests/Utils/Links/ThrowingLink.cs
+++ b/tests/DaisyFx.Tests/Utils/Links/ThrowingLink.cs
@@ -4,7 +4,7 @@ namespace DaisyFx.Tests.Utils.Links
 {
     public class ThrowingLink<T> : StatelessLink<T, T>
     {
-        protected override ValueTask<T> Invoke(T input, ChainContext context)
+        protected override ValueTask<T> ExecuteAsync(T input, ChainContext context)
         {
             throw new TestException();
         }


### PR DESCRIPTION
Renames the link `Invoke` method to `ExecuteAsync`.

- Aligns with `Source.ExecuteAsync`
- Adheres to the .net async naming convention