### PR TITLE
Reorder ChainBuilder methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ public class ExampleChain : ChainBuilder<Signal>
 {
     public override string Name { get; } = "ExampleChain";
 
+    public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
+    {
+        sources.Add<NCrontabSource>("Cron");
+    }
+
     public override void ConfigureRootConnector(IConnectorLinker<Signal> root)
     {
         root.Link<GetDataRecords, DataRecord[]>()
@@ -28,11 +33,6 @@ public class ExampleChain : ChainBuilder<Signal>
                 .Link<PersistRecord, RecordModel>()
                 .Link<SendEmail, RecordMoadel>()
             );
-    }
-
-    public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
-    {
-        sources.Add<NCrontabSource>("Cron");
     }
 
     private static RecordModel[] MapRecords(DataRecord[] input)
@@ -57,6 +57,11 @@ public class ExampleChain : ChainBuilder<Signal>
 {
     public override string Name { get; } = "ExampleChain";
 
+    public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
+    {
+        sources.Add<NCrontabSource, Signal>("Cron");
+    }
+
     public override void ConfigureRootConnector(IConnectorLinker<Signal> root)
     {
         root.Map(_ => 
@@ -64,11 +69,6 @@ public class ExampleChain : ChainBuilder<Signal>
                 Console.WriteLine("Creating string");
                 return "Hey";
             });
-    }
-
-    public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
-    {
-        sources.Add<NCrontabSource, Signal>("Cron");
     }
 }
 ```

--- a/samples/DaisyFx.Samples.KitchenSink/KitchenSinkChain.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/KitchenSinkChain.cs
@@ -10,6 +10,12 @@ namespace DaisyFx.Samples.KitchenSink
     {
         public override string Name { get; } = "KitchenSink";
 
+        public override void ConfigureSources(SourceConnectorCollection<string> sources)
+        {
+            sources.Add<DateTimeStringSource>("DateTimeStringSource");
+            sources.Add<NCrontabSource, Signal>("Cron", _ => DateTime.Now.ToString(CultureInfo.InvariantCulture));
+        }
+
         public override void ConfigureRootConnector(IConnectorLinker<string> root)
         {
             root.Conditional(string.IsNullOrEmpty, _ => _
@@ -30,12 +36,6 @@ namespace DaisyFx.Samples.KitchenSink
                         )))
                 .Link<StringToDateTime, DateTime>()
                 .Link<LogDateTime, DateTime>();
-        }
-
-        public override void ConfigureSources(SourceConnectorCollection<string> sources)
-        {
-            sources.Add<DateTimeStringSource>("DateTimeStringSource");
-            sources.Add<NCrontabSource, Signal>("Cron", _ => DateTime.Now.ToString(CultureInfo.InvariantCulture));
         }
 
         private static bool IsDivisibleBy3(int input)

--- a/samples/DaisyFx.Samples.LoanBroker/Chains/LoanBrokerChain.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Chains/LoanBrokerChain.cs
@@ -8,6 +8,11 @@ namespace DaisyFx.Samples.LoanBroker.Chains
     {
         public override string Name { get; } = "LoanBroker";
 
+        public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
+        {
+            sources.Add<NCrontabSource>("Cron");
+        }
+
         public override void ConfigureRootConnector(IConnectorLinker<Signal> root)
         {
             root.Link<GetLoanInquiry, LoanInquiry>()
@@ -18,11 +23,6 @@ namespace DaisyFx.Samples.LoanBroker.Chains
                 )
                 .Link<CreateLoanContract, LoanContract>()
                 .Link<ApproveLoan, Signal>();
-        }
-
-        public override void ConfigureSources(SourceConnectorCollection<Signal> sources)
-        {
-            sources.Add<NCrontabSource>("Cron");
         }
 
         private static bool CreditScoreIsBad(LoanApplication application)

--- a/samples/DaisyFx.Samples.Webhook/OrderChain.cs
+++ b/samples/DaisyFx.Samples.Webhook/OrderChain.cs
@@ -8,14 +8,14 @@ namespace DaisyFx.Samples.Webhook
     {
         public override string Name { get; } = "Order";
 
-        public override void ConfigureRootConnector(IConnectorLinker<Order> root)
-        {
-            root.Link<PrintOrderToConsole, Order>();
-        }
-
         public override void ConfigureSources(SourceConnectorCollection<Order> sources)
         {
             sources.Add<OrderHttpSource>("Http");
+        }
+
+        public override void ConfigureRootConnector(IConnectorLinker<Order> root)
+        {
+            root.Link<PrintOrderToConsole, Order>();
         }
     }
 }

--- a/src/DaisyFx/ChainBuilder.cs
+++ b/src/DaisyFx/ChainBuilder.cs
@@ -9,8 +9,8 @@ namespace DaisyFx
         public abstract string Name { get; }
 
         public virtual ILockStrategy CreateLockStrategy() => NoLockStrategy.Static;
-        public abstract void ConfigureRootConnector(IConnectorLinker<T> root);
         public abstract void ConfigureSources(SourceConnectorCollection<T> sources);
+        public abstract void ConfigureRootConnector(IConnectorLinker<T> root);
 
         IChain IChainBuilder.BuildChain(IServiceProvider serviceProvider)
         {

--- a/tests/DaisyFx.Tests/Sources/HttpSource/HttpTestChain.cs
+++ b/tests/DaisyFx.Tests/Sources/HttpSource/HttpTestChain.cs
@@ -4,14 +4,14 @@ namespace DaisyFx.Tests.Sources.HttpSource
     {
         public override string Name { get; } = "Test";
 
-        public override void ConfigureRootConnector(IConnectorLinker<HttpTestPayload> root)
-        {
-            root.Map(x => x);
-        }
-
         public override void ConfigureSources(SourceConnectorCollection<HttpTestPayload> sources)
         {
             sources.Add<HttpTestSource>("http");
+        }
+
+        public override void ConfigureRootConnector(IConnectorLinker<HttpTestPayload> root)
+        {
+            root.Map(x => x);
         }
     }
 }

--- a/tests/DaisyFx.Tests/Utils/Chains/TestChain.cs
+++ b/tests/DaisyFx.Tests/Utils/Chains/TestChain.cs
@@ -22,14 +22,14 @@ namespace DaisyFx.Tests.Utils.Chains
             return LockStrategy ?? base.CreateLockStrategy();
         }
 
-        public override void ConfigureRootConnector(IConnectorLinker<T> root)
-        {
-            ConfigureRootAction?.Invoke(root);
-        }
-
         public override void ConfigureSources(SourceConnectorCollection<T> sources)
         {
             ConfigureSourcesAction?.Invoke(sources);
+        }
+
+        public override void ConfigureRootConnector(IConnectorLinker<T> root)
+        {
+            ConfigureRootAction?.Invoke(root);
         }
     }
 }


### PR DESCRIPTION
Moves `ConfigureSources` before `ConfigureRootConnector`, this resembles the execution order of a chain.