### PR TITLE
Rename usage of conditional sub-chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Used to represent a message without any data flowing through a chain.
 - [Link](#Link)
 - [Map](#Map)
 - [SubChain](#SubChain)
-- [Conditional](#Conditional)
+- [If](#If)
 - [Each](#Each)
 
 ### Link
@@ -266,12 +266,12 @@ public static class DivisionSubChain
 }
 ```
 
-### Conditional
+### If
 
 A control flow which executes the sub-chain if the predicate evaluates to true.
 
 ```
-root.Conditional(IsDivisibleBy3, then => then
+root.If(IsDivisibleBy3, then => then
         .Map(_ => "Value was divisible by 3")
         .Link<ConsoleWriteLine, string>());
 ```

--- a/samples/DaisyFx.Samples.KitchenSink/KitchenSinkChain.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/KitchenSinkChain.cs
@@ -18,20 +18,20 @@ namespace DaisyFx.Samples.KitchenSink
 
         public override void ConfigureRootConnector(IConnectorLinker<string> root)
         {
-            root.Conditional(string.IsNullOrEmpty, _ => _
+            root.If(string.IsNullOrEmpty, _ => _
                     .Complete("Payload is empty"))
                 .SubChain(subChain => subChain
                     .Link<GenerateArray, int[]>("GenerateArray")
                     .Each(each => each
-                        .Conditional(IsDivisibleBy3, then => then
+                        .If(IsDivisibleBy3, then => then
                             .Map(_ => "Fizz")
                             .Link<LogInformation<string>, string>()
                         )
-                        .Conditional(IsDivisibleBy5, then => then
+                        .If(IsDivisibleBy5, then => then
                             .Map(_ => "Buzz")
                             .Link<LogInformation<string>, string>()
                         )
-                        .Conditional(i => !IsDivisibleBy3(i) && !IsDivisibleBy5(i), then => then
+                        .If(i => !IsDivisibleBy3(i) && !IsDivisibleBy5(i), then => then
                             .Link<LogInformation<int>, int>()
                         )))
                 .Link<StringToDateTime, DateTime>()

--- a/samples/DaisyFx.Samples.LoanBroker/Chains/LoanBrokerChain.cs
+++ b/samples/DaisyFx.Samples.LoanBroker/Chains/LoanBrokerChain.cs
@@ -17,7 +17,7 @@ namespace DaisyFx.Samples.LoanBroker.Chains
         {
             root.Link<GetLoanInquiry, LoanInquiry>()
                 .Link<CreateLoanApplication, LoanApplication>()
-                .Conditional(CreditScoreIsBad, builder => builder
+                .If(CreditScoreIsBad, then => then
                     .Link<DenyLoan, Signal>()
                     .Complete("Denied")
                 )

--- a/src/DaisyFx/ConnectorLinkerExtensions.cs
+++ b/src/DaisyFx/ConnectorLinkerExtensions.cs
@@ -24,7 +24,7 @@ namespace DaisyFx
             parent.Link(connector);
         }
 
-        public static IConnectorLinker<T> Conditional<T>(this IConnectorLinker<T> parent, Predicate<T> predicate, Action<IConnectorLinker<T>> buildChain)
+        public static IConnectorLinker<T> If<T>(this IConnectorLinker<T> parent, Predicate<T> predicate, Action<IConnectorLinker<T>> buildChain)
         {
             var connector = new ConditionalSubChainConnector<T>(predicate, buildChain, parent.Context);
             parent.Link(connector);

--- a/tests/DaisyFx.Tests/Connectors/ConditionalSubChainConnectorTests.cs
+++ b/tests/DaisyFx.Tests/Connectors/ConditionalSubChainConnectorTests.cs
@@ -23,10 +23,10 @@ namespace DaisyFx.Tests.Connectors
             var chainBuilder = new TestChain<string>
             {
                 ConfigureRootAction = root => root
-                    .Conditional(payload1.Equals, builder => builder
+                    .If(payload1.Equals, then => then
                         .TestInspect(onProcess: (input, _) => result1.Add(input))
                     )
-                    .Conditional(payload2.Equals, builder => builder
+                    .If(payload2.Equals, then => then
                         .TestInspect(onProcess: (input, _) => result2.Add(input))
                     )
             };
@@ -53,7 +53,7 @@ namespace DaisyFx.Tests.Connectors
             var chainBuilder = new TestChain<string>
             {
                 ConfigureRootAction = root => root
-                    .Conditional(payload.Equals, builder => builder
+                    .If(payload.Equals, then => then
                         .Link<NoopLink<string>, string>()
                     )
                     .TestInspect(onProcess: (input, _) => result.Add(input))
@@ -72,7 +72,7 @@ namespace DaisyFx.Tests.Connectors
             var chainBuilder = new TestChain<Signal>
             {
                 ConfigureRootAction = root => root
-                    .Conditional(_ => true, builder => builder
+                    .If(_ => true, then => then
                         .TestInspect(onDispose: () => subChainDisposed = true)
                     )
             };


### PR DESCRIPTION
Before:
```csharp
root.Conditional(IsDivisibleBy3, then => then
        .Map(_ => "Value was divisible by 3")
        .Link<ConsoleWriteLine, string>()
    );
```

After:
```csharp
root.If(IsDivisibleBy3, then => then
        .Map(_ => "Value was divisible by 3")
        .Link<ConsoleWriteLine, string>()
    );
```