### PR TITLE
Add RegisterForDispose and RegisterForDisposeAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 ## Unreleased
+### Breaking Changes
+- Add RegisterForDispose and RegisterForDisposeAsync on ChainContext
+
+Previously values added by calling `ChainContext.Set(key, value)` was disposed if the value implemented `IDisposable`,
+this has been removed and you are instead expected to call `ChainContext.RegisterForDispose(item)` or `ChainContext.RegisterForDisposeAsync(item)`
+depending on if the item implements `IDisposable` or `IAsyncDisposable`.
+
+- Dispose registered items after current scope is completed
+
+All items registered for dispose on the ChainContext in an `.Each(each => each..)` is now disposed after each enumeration, 
+similarly for `.SubChain(subChain => subChain..)` and `.If(_ => ..., then => then..)` the dispose happens when that scope has completed.
+
+Everything registered in the root scope is disposed when the chain execution completes before returning the result.
 
 ## 0.0.4
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Connectors are the steps that form a chain. Created using a fluent builder, they
 
 ### ChainContext
 
-The ChainContext is a control interface that provides access to a per-execution scoped data collection, utilities and manipulation of the execution itself. The data collection allows steps to communicate without having to flow the data as input / output through the chain. The collection items are discarded and disposed after the execution is done.
+The ChainContext is a control interface that provides access to a per-execution scoped data collection, utilities and manipulation of the execution itself. The data collection allows steps to communicate without having to flow the data as input / output through the chain. The collection items are discarded after the execution is done.
 
 #### Set
 
@@ -151,6 +151,15 @@ if(context.TryGet("Foo", out string fooValue))
 {
     context.Logger.LogInformation(fooValue);
 }
+```
+
+#### RegisterForDispose and RegisterForDisposeAsync
+
+Registers an instance of `IDisposable` or `IAsyncDisposable` that should be disposed after the current scope is completed
+
+```
+context.RegisterForDispose(disposable);
+context.RegisterForDisposeAsync(asyncDisposable);
 ```
 
 #### Logger

--- a/samples/DaisyFx.Samples.KitchenSink/Links/GenerateArray.cs
+++ b/samples/DaisyFx.Samples.KitchenSink/Links/GenerateArray.cs
@@ -1,20 +1,36 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace DaisyFx.Samples.KitchenSink.Links
 {
     public class GenerateArray : StatelessLink<string, int[]>
     {
+        private readonly ILogger<GenerateArray> _logger;
         private readonly GenerateArrayOptions _config;
 
-        public GenerateArray()
+        public GenerateArray(ILogger<GenerateArray> logger)
         {
+            _logger = logger;
             _config = ReadConfiguration<GenerateArrayOptions>();
         }
 
         protected override ValueTask<int[]> ExecuteAsync(string input, ChainContext context)
         {
+            _logger.LogInformation("Producing value");
+            context.RegisterForDispose(new DisposableAction(LogScopeCompleted));
             return new(Enumerable.Range(_config.Start, _config.Count).ToArray());
+        }
+
+        private void LogScopeCompleted()
+        {
+            _logger.LogInformation("Scope completed");
+        }
+
+        protected override void Dispose()
+        {
+            _logger.LogInformation("Disposing");
+            base.Dispose();
         }
     }
 

--- a/src/DaisyFx/Chain.cs
+++ b/src/DaisyFx/Chain.cs
@@ -82,7 +82,7 @@ namespace DaisyFx
             await LockStrategy.RequestLockAsync(cancellationToken);
             _logger.Executing();
 
-            using var context = new ChainContext(Name, _serviceProvider, cancellationToken);
+            await using var context = new ChainContext(Name, _serviceProvider, cancellationToken);
 
             try
             {

--- a/src/DaisyFx/ChainContext.cs
+++ b/src/DaisyFx/ChainContext.cs
@@ -1,15 +1,32 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using System.Threading.Tasks;
 using DaisyFx.Events;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace DaisyFx
 {
-    public class ChainContext : IReadOnlyChainContext, IDisposable
+    public class ChainContext : IReadOnlyChainContext, IAsyncDisposable
     {
+        private static readonly Func<object, ValueTask> DisposeDelegate = state =>
+        {
+            // Prefer async dispose over dispose
+            if (state is IAsyncDisposable asyncDisposable)
+            {
+                return asyncDisposable.DisposeAsync();
+            }
+            else if (state is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+
+            return new();
+        };
+
         private readonly Lazy<ConcurrentDictionary<object, object>> _lazyItemsCollection;
         private readonly IServiceScope _serviceScope;
 
@@ -23,8 +40,10 @@ namespace DaisyFx
             _lazyItemsCollection = new Lazy<ConcurrentDictionary<object, object>>();
             EventBroker = new EventBroker(_serviceScope.ServiceProvider);
             CancellationToken = cancellationToken;
+            OnComplete = new Stack<(Func<object, ValueTask> callback, object state)>();
         }
 
+        internal Stack<(Func<object, ValueTask> callback, object state)> OnComplete { get; }
         internal IServiceProvider ApplicationServices { get; }
         internal EventBroker EventBroker { get; }
         internal IServiceProvider ScopeServices => _serviceScope.ServiceProvider;
@@ -57,19 +76,28 @@ namespace DaisyFx
             return true;
         }
 
-        void IDisposable.Dispose()
+        public void RegisterForDispose(IDisposable disposable)
+        {
+            OnComplete.Push((DisposeDelegate, disposable));
+        }
+
+        public void RegisterForDisposeAsync(IAsyncDisposable disposable)
+        {
+            OnComplete.Push((DisposeDelegate, disposable));
+        }
+
+        public async ValueTask DisposeAsync()
         {
             _serviceScope.Dispose();
 
             if (_lazyItemsCollection.IsValueCreated)
             {
-                foreach (var value in _lazyItemsCollection.Value.Values)
-                {
-                    if(value is IDisposable disposable)
-                    {
-                        disposable.Dispose();
-                    }
-                }
+                _lazyItemsCollection.Value.Clear();
+            }
+
+            while (OnComplete.TryPop(out var disposable))
+            {
+                await disposable.callback(disposable.state);
             }
         }
     }

--- a/src/DaisyFx/ChainContext.cs
+++ b/src/DaisyFx/ChainContext.cs
@@ -86,7 +86,7 @@ namespace DaisyFx
             OnComplete.Push((DisposeDelegate, disposable));
         }
 
-        public async ValueTask DisposeAsync()
+        async ValueTask IAsyncDisposable.DisposeAsync()
         {
             _serviceScope.Dispose();
 

--- a/src/DaisyFx/ChainContext.cs
+++ b/src/DaisyFx/ChainContext.cs
@@ -88,8 +88,6 @@ namespace DaisyFx
 
         async ValueTask IAsyncDisposable.DisposeAsync()
         {
-            _serviceScope.Dispose();
-
             if (_lazyItemsCollection.IsValueCreated)
             {
                 _lazyItemsCollection.Value.Clear();
@@ -99,6 +97,8 @@ namespace DaisyFx
             {
                 await disposable.callback(disposable.state);
             }
+
+            _serviceScope.Dispose();
         }
     }
 }

--- a/src/DaisyFx/Connectors/ConditionalSubChainConnector.cs
+++ b/src/DaisyFx/Connectors/ConditionalSubChainConnector.cs
@@ -19,7 +19,15 @@ namespace DaisyFx.Connectors
         {
             if (_predicate(input))
             {
+                var onCompleteCountBefore = context.OnComplete.Count;
+
                 await _conditionalConnector.ProcessAsync(input, context);
+
+                for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+                {
+                    var (callback, state) = context.OnComplete.Pop();
+                    await callback(state);
+                }
             }
 
             return input;

--- a/src/DaisyFx/Connectors/ConditionalSubChainConnector.cs
+++ b/src/DaisyFx/Connectors/ConditionalSubChainConnector.cs
@@ -23,7 +23,7 @@ namespace DaisyFx.Connectors
 
                 await _conditionalConnector.ProcessAsync(input, context);
 
-                for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+                while(context.OnComplete.Count > onCompleteCountBefore)
                 {
                     var (callback, state) = context.OnComplete.Pop();
                     await callback(state);

--- a/src/DaisyFx/Connectors/EnumerationConnector.cs
+++ b/src/DaisyFx/Connectors/EnumerationConnector.cs
@@ -24,7 +24,7 @@ namespace DaisyFx.Connectors
 
                 await _connector.ProcessAsync(input[i], context);
 
-                for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+                while(context.OnComplete.Count > onCompleteCountBefore)
                 {
                     var (callback, state) = context.OnComplete.Pop();
                     await callback(state);

--- a/src/DaisyFx/Connectors/EnumerationConnector.cs
+++ b/src/DaisyFx/Connectors/EnumerationConnector.cs
@@ -20,7 +20,15 @@ namespace DaisyFx.Connectors
             {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
+                var onCompleteCountBefore = context.OnComplete.Count;
+
                 await _connector.ProcessAsync(input[i], context);
+
+                for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+                {
+                    var (callback, state) = context.OnComplete.Pop();
+                    await callback(state);
+                }
             }
 
             return input;

--- a/src/DaisyFx/Connectors/StatelessLinkConnector.cs
+++ b/src/DaisyFx/Connectors/StatelessLinkConnector.cs
@@ -18,7 +18,8 @@ namespace DaisyFx.Connectors
 
         protected override async ValueTask<TOutput> ProcessAsync(TInput input, ChainContext context)
         {
-            using var link = InstanceFactory.Create<TLink>(context.ScopeServices, _context);
+            var link = InstanceFactory.Create<TLink>(context.ScopeServices, _context);
+            context.RegisterForDispose(link);
             return await link.ExecuteAsync(input, context);
         }
     }

--- a/src/DaisyFx/Connectors/SubChainConnector.cs
+++ b/src/DaisyFx/Connectors/SubChainConnector.cs
@@ -18,7 +18,7 @@ namespace DaisyFx.Connectors
 
             await _connector.ProcessAsync(input, context);
 
-            for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+            while(context.OnComplete.Count > onCompleteCountBefore)
             {
                 var (callback, state) = context.OnComplete.Pop();
                 await callback(state);

--- a/src/DaisyFx/Connectors/SubChainConnector.cs
+++ b/src/DaisyFx/Connectors/SubChainConnector.cs
@@ -14,7 +14,16 @@ namespace DaisyFx.Connectors
 
         protected override async ValueTask<TInput> ProcessAsync(TInput input, ChainContext context)
         {
+            var onCompleteCountBefore = context.OnComplete.Count;
+
             await _connector.ProcessAsync(input, context);
+
+            for (var _ = context.OnComplete.Count; _ > onCompleteCountBefore; _--)
+            {
+                var (callback, state) = context.OnComplete.Pop();
+                await callback(state);
+            }
+
             return input;
         }
 

--- a/tests/DaisyFx.TestHelpers/StatefulLinkTestRunner.cs
+++ b/tests/DaisyFx.TestHelpers/StatefulLinkTestRunner.cs
@@ -20,7 +20,7 @@ namespace DaisyFx.TestHelpers
 
         public async ValueTask<TOutput> ExecuteAsync(TInput input, CancellationToken ct = default)
         {
-            using var context = CreateContext(Services, ct);
+            await using var context = CreateContext(Services, ct);
             return await _link.ExecuteAsync(input, context);
         }
 

--- a/tests/DaisyFx.TestHelpers/StatelessLinkTestRunner.cs
+++ b/tests/DaisyFx.TestHelpers/StatelessLinkTestRunner.cs
@@ -8,7 +8,7 @@ namespace DaisyFx.TestHelpers
     {
         public async ValueTask<TOutput> ExecuteAsync(TInput input, CancellationToken ct = default)
         {
-            using var context = CreateContext(Services, ct);
+            await using var context = CreateContext(Services, ct);
             using ILink<TInput, TOutput> link = CreateLink(context.ScopeServices);
 
             return await link.ExecuteAsync(input, context);

--- a/tests/DaisyFx.Tests/ChainContextTests.cs
+++ b/tests/DaisyFx.Tests/ChainContextTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using DaisyFx.Tests.Utils;
 using DaisyFx.Tests.Utils.Logging;
 using Microsoft.Extensions.DependencyInjection;
@@ -96,16 +97,20 @@ namespace DaisyFx.Tests
         }
 
         [Fact]
-        public void Dispose_DisposesItems()
+        public async Task Dispose_DisposesRegisterForDisposeRegistrations()
         {
-            var item = new FakeItem();
-            using (var context = CreateChainContext())
+            var fakeDisposable = new FakeDisposable();
+            var fakeAsyncDisposable = new FakeAsyncDisposable();
+            await using (var context = CreateChainContext())
             {
-                context.Set("TestKey", item);
+                context.RegisterForDispose(fakeDisposable);
+                context.RegisterForDisposeAsync(fakeAsyncDisposable);
             }
 
-            Assert.True(item.Disposed);
+            Assert.True(fakeDisposable.Disposed);
+            Assert.True(fakeAsyncDisposable.Disposed);
         }
+
 
         private static ChainContext CreateChainContext(string name = "TestName", TestLogSink? logSink = null)
         {
@@ -120,16 +125,6 @@ namespace DaisyFx.Tests
             );
 
             return new ChainContext(name, serviceProvider, CancellationToken.None);
-        }
-
-        private class FakeItem : IDisposable
-        {
-            public bool Disposed { get; private set; }
-
-            public void Dispose()
-            {
-                Disposed = true;
-            }
         }
     }
 }

--- a/tests/DaisyFx.Tests/Connectors/EnumerationConnectorTests.cs
+++ b/tests/DaisyFx.Tests/Connectors/EnumerationConnectorTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DaisyFx.Tests.Utils;
 using DaisyFx.Tests.Utils.Chains;
 using DaisyFx.Tests.Utils.Extensions;
 using Xunit;
@@ -53,6 +54,29 @@ namespace DaisyFx.Tests.Connectors
             await chainBuilder.BuildAndExecuteAsync(payload, cancellationTokenSource.Token);
 
             Assert.True(payload.Take(maxIterations).SequenceEqual(result));
+        }
+
+        [Fact]
+        public async Task ItemEnumerated_DisposesRegisteredDisposables()
+        {
+            var input = new[] {Signal.Static, Signal.Static};
+            var chainDisposableCount = 0;
+            var fakeDisposable = new FakeDisposable();
+            var chainBuilder = new TestChain<Signal[]>
+            {
+                ConfigureRootAction = root => root
+                    .Each(each => each
+                        .TestInspect(onProcess: (_, context) => context.RegisterForDispose(fakeDisposable))
+                    )
+                    .TestInspect(onProcess: (_, context) => chainDisposableCount = context.OnComplete.Count)
+            };
+
+            var chain = await chainBuilder.BuildAsync();
+            var result = await chain.ExecuteAsync(input, default);
+
+            Assert.Equal(ExecutionResultStatus.Completed, result.Status);
+            Assert.Equal(0, chainDisposableCount);
+            Assert.Equal(input.Length, fakeDisposable.DisposeCount);
         }
     }
 }

--- a/tests/DaisyFx.Tests/Utils/FakeAsyncDisposable.cs
+++ b/tests/DaisyFx.Tests/Utils/FakeAsyncDisposable.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DaisyFx.Tests.Utils
+{
+    public class FakeAsyncDisposable : IAsyncDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return new();
+        }
+    }
+}

--- a/tests/DaisyFx.Tests/Utils/FakeDisposable.cs
+++ b/tests/DaisyFx.Tests/Utils/FakeDisposable.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace DaisyFx.Tests.Utils
+{
+    public class FakeDisposable : IDisposable
+    {
+        public bool Disposed => DisposeCount > 0;
+        public int DisposeCount { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+    }
+}


### PR DESCRIPTION
### Breaking Changes
- Add RegisterForDispose and RegisterForDisposeAsync on ChainContext

Previously values added by calling `ChainContext.Set(key, value)` was disposed if the value implemented `IDisposable`,
this has been removed and you are instead expected to call `ChainContext.RegisterForDispose(item)` or `ChainContext.RegisterForDisposeAsync(item)`
depending on if the item implements `IDisposable` or `IAsyncDisposable`.

- Dispose registered items after current scope is completed

All items registered for dispose on the ChainContext in an `.Each(each => each..)` is now disposed after each enumeration, 
similarly for `.SubChain(subChain => subChain..)` and `.If(_ => ..., then => then..)` the dispose happens when that scope has completed.

Everything registered in the root scope is disposed when the chain execution completes before returning the result.
